### PR TITLE
Rename the imports in the binary

### DIFF
--- a/gof3r/cp.go
+++ b/gof3r/cp.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rlmcpherson/s3gof3r"
+	"github.com/github/s3gof3r"
 )
 
 type CpArg struct {

--- a/gof3r/get.go
+++ b/gof3r/get.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/rlmcpherson/s3gof3r"
+	"github.com/github/s3gof3r"
 )
 
 type getOpts struct {

--- a/gof3r/main.go
+++ b/gof3r/main.go
@@ -37,8 +37,8 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/github/s3gof3r"
 	"github.com/jessevdk/go-flags"
-	"github.com/rlmcpherson/s3gof3r"
 )
 
 const (

--- a/gof3r/put.go
+++ b/gof3r/put.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/rlmcpherson/s3gof3r"
+	"github.com/github/s3gof3r"
 )
 
 type putOpts struct {

--- a/gof3r/rm.go
+++ b/gof3r/rm.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/rlmcpherson/s3gof3r"
+	"github.com/github/s3gof3r"
 )
 
 type rmOpts struct {


### PR DESCRIPTION
Otherwise we end up vendoring both versions when trying to use this version of
the library.