### PR TITLE
Fix hang when retries fail.

### DIFF
--- a/getter_test.go
+++ b/getter_test.go
@@ -1,0 +1,71 @@
+package s3gof3r
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func NewFakeGetter(testurl string) (io.ReadCloser, error) {
+	s3obj := New("s3.amazonaws.com", Keys{})
+	b := s3obj.Bucket("foobucket")
+	u, err := url.Parse(testurl)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse url: %s", testurl)
+	}
+	c := b.conf()
+	c.NTry = 1
+	g, _, err := newGetter(*u, c, b)
+	if err != nil {
+		return nil, fmt.Errorf("newGetter() %s", err)
+	}
+	return g, nil
+}
+
+// Verify graceful recovery (don't hang) when we receive the target
+// content length but subsequent chunk requests fail.
+func TestFailedGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "2") // trigger unexpected EOF in the client
+		fmt.Fprintln(w, "")
+	}))
+	defer ts.Close()
+
+	g, err := NewFakeGetter(ts.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	defer g.Close()
+
+	_, err = ioutil.ReadAll(g)
+	if err == nil {
+		t.Error("Expected ReadAll() to return an error")
+	}
+}
+
+// Verify successful read when everything is working correctly.
+func TestGetterHappyPath(t *testing.T) {
+	expStr := "happy test"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, expStr)
+	}))
+	defer ts.Close()
+
+	g, err := NewFakeGetter(ts.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	defer g.Close()
+
+	d, err := ioutil.ReadAll(g)
+	if err != nil {
+		t.Error("ReadAll():", err)
+	}
+	if string(d[:len(d)-1]) != expStr { // strip trailing newline
+		t.Errorf("Expected data to be: '%v'. Actual: '%v'", expStr, d)
+	}
+}


### PR DESCRIPTION
The getter can hang when we manage to get past the initial request
for the content length, but all subsequent chunk requests fail.
When this happens, the sending (`worker()`) side never closes the
`g.readCh` channel, and thus the reading side blocks forever on select.

This change adds a `workerAborted` channel to signal to Read() callers that
something went wrong while trying to fetch all the chunks. As multiple worker
goroutines may encounter problems, we wrap the `close(workerAborted)` call
in a `sync.Once` to avoid `panic()`ing by closing a closed channel.

Tests are included to both verify the broken behavior prior to the
change (the test hangs without this fix) and verify the happy path
still works as expected.

cc @carlosmn 