### PR TITLE
checkClose() should return err from close().

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -40,7 +40,7 @@ func InstanceKeys() (keys Keys, err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		err = newRespError(resp)
 		return
@@ -56,7 +56,7 @@ func InstanceKeys() (keys Keys, err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		err = newRespError(resp)
 		return

--- a/delete_multiple.go
+++ b/delete_multiple.go
@@ -80,7 +80,7 @@ func deleteMultiple(c *Config, b *Bucket, quiet bool, keys []string) (DeleteResu
 	if err != nil {
 		return DeleteResult{}, err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return DeleteResult{}, newRespError(resp)
 	}

--- a/getter.go
+++ b/getter.go
@@ -79,7 +79,7 @@ func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header
 	if err != nil {
 		return nil, nil, err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, nil, newRespError(resp)
 	}
@@ -197,7 +197,7 @@ func (g *getter) getChunk(c *chunk) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 206 && resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
@@ -341,7 +341,7 @@ func (g *getter) checkMd5() (err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("MD5 check failed: %s not found: %s", md5Url.String(), newRespError(resp))
 	}

--- a/list_objects.go
+++ b/list_objects.go
@@ -217,7 +217,7 @@ func listObjects(c *Config, b *Bucket, opts listObjectsOptions) (result *listBuc
 	if err != nil {
 		return nil, err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, newRespError(resp)
 	}

--- a/putter.go
+++ b/putter.go
@@ -91,7 +91,7 @@ func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (p *putter, err
 	if err != nil {
 		return nil, err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return nil, newRespError(resp)
 	}
@@ -212,7 +212,7 @@ func (p *putter) putPart(part *part) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
@@ -274,7 +274,7 @@ func (p *putter) Close() (err error) {
 			p.abort()
 			return
 		}
-		defer checkClose(resp.Body, err)
+		defer checkClose(resp.Body)
 		if resp.StatusCode != 200 {
 			p.abort()
 			return newRespError(resp)
@@ -346,7 +346,7 @@ func (p *putter) abort() {
 		logger.Printf("Error aborting multipart upload: %v\n", err)
 		return
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 204 {
 		logger.Printf("Error aborting multipart upload: %v", newRespError(resp))
 	}
@@ -393,7 +393,7 @@ func (p *putter) putMd5() (err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 200 {
 		return newRespError(resp)
 	}

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -219,7 +219,7 @@ func (b *Bucket) delete(path string) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
+	defer checkClose(resp.Body)
 	if resp.StatusCode != 204 {
 		return newRespError(resp)
 	}

--- a/util.go
+++ b/util.go
@@ -77,12 +77,9 @@ func (e *RespError) Error() string {
 	)
 }
 
-func checkClose(c io.Closer, err error) {
+func checkClose(c io.Closer) (err error) {
 	if c != nil {
-		cerr := c.Close()
-		if err == nil {
-			err = cerr
-		}
+		err = c.Close()
 	}
-
+	return err
 }


### PR DESCRIPTION
Currently `checkClose()` pointlessly assigns the return value from close()
to a local variable. Although none of the call sites check this error
anyway, let's make it feasible to do so, while also getting rid of code
that confusingly has no practical effect.

Spotted by @mhagger . 

cc: @github/git-storage 