### PR TITLE
Fix handling of response errors and closing of `resp.Body()`

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -40,13 +40,13 @@ func InstanceKeys() (keys Keys, err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		err = newRespError(resp)
 		return
 	}
-	role, err := ioutil.ReadAll(resp.Body)
+	defer checkClose(resp.Body, err)
 
+	role, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}
@@ -56,11 +56,12 @@ func InstanceKeys() (keys Keys, err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		err = newRespError(resp)
 		return
 	}
+	defer checkClose(resp.Body, err)
+
 	metadata, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return

--- a/delete_multiple.go
+++ b/delete_multiple.go
@@ -83,11 +83,15 @@ func deleteMultiple(c *Config, b *Bucket, quiet bool, keys []string) (DeleteResu
 	if resp.StatusCode != 200 {
 		return DeleteResult{}, newRespError(resp)
 	}
-	defer checkClose(resp.Body, err)
 
 	var result DeleteResult
 	decoder := xml.NewDecoder(resp.Body)
 	if err := decoder.Decode(&result); err != nil {
+		_ = resp.Body.Close()
+		return DeleteResult{}, err
+	}
+
+	if err := resp.Body.Close(); err != nil {
 		return DeleteResult{}, err
 	}
 

--- a/delete_multiple.go
+++ b/delete_multiple.go
@@ -80,10 +80,10 @@ func deleteMultiple(c *Config, b *Bucket, quiet bool, keys []string) (DeleteResu
 	if err != nil {
 		return DeleteResult{}, err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return DeleteResult{}, newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
 
 	var result DeleteResult
 	decoder := xml.NewDecoder(resp.Body)

--- a/getter.go
+++ b/getter.go
@@ -82,7 +82,8 @@ func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header
 	if resp.StatusCode != 200 {
 		return nil, nil, newRespError(resp)
 	}
-	defer checkClose(resp.Body, err)
+	// Otherwise, we don't need the body:
+	_ = resp.Body.Close()
 
 	// Golang changes content-length to -1 when chunked transfer encoding / EOF close response detected
 	if resp.ContentLength == -1 {

--- a/getter.go
+++ b/getter.go
@@ -201,10 +201,10 @@ func (g *getter) getChunk(c *chunk) error {
 	if resp.StatusCode != 206 && resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
-	defer checkClose(resp.Body, err)
 
 	n, err := io.ReadAtLeast(resp.Body, c.b, int(c.size))
 	if err != nil {
+		_ = resp.Body.Close()
 		return err
 	}
 	if err := resp.Body.Close(); err != nil {

--- a/getter.go
+++ b/getter.go
@@ -79,10 +79,10 @@ func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header
 	if err != nil {
 		return nil, nil, err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return nil, nil, newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
 
 	// Golang changes content-length to -1 when chunked transfer encoding / EOF close response detected
 	if resp.ContentLength == -1 {
@@ -197,10 +197,11 @@ func (g *getter) getChunk(c *chunk) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 206 && resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
+
 	n, err := io.ReadAtLeast(resp.Body, c.b, int(c.size))
 	if err != nil {
 		return err
@@ -341,10 +342,11 @@ func (g *getter) checkMd5() (err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("MD5 check failed: %s not found: %s", md5Url.String(), newRespError(resp))
 	}
+	defer checkClose(resp.Body, err)
+
 	givenMd5, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return

--- a/list_objects.go
+++ b/list_objects.go
@@ -217,10 +217,10 @@ func listObjects(c *Config, b *Bucket, opts listObjectsOptions) (result *listBuc
 	if err != nil {
 		return nil, err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return nil, newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
 
 	decoder := xml.NewDecoder(resp.Body)
 	if err := decoder.Decode(result); err != nil {

--- a/putter.go
+++ b/putter.go
@@ -216,7 +216,9 @@ func (p *putter) putPart(part *part) error {
 	if resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
-	defer checkClose(resp.Body, err)
+	if err := resp.Body.Close(); err != nil {
+		return err
+	}
 
 	s := resp.Header.Get("etag")
 	if len(s) < 2 {

--- a/putter.go
+++ b/putter.go
@@ -91,10 +91,11 @@ func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (p *putter, err
 	if err != nil {
 		return nil, err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return nil, newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
+
 	err = xml.NewDecoder(resp.Body).Decode(p)
 	if err != nil {
 		return nil, err
@@ -212,10 +213,11 @@ func (p *putter) putPart(part *part) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
+
 	s := resp.Header.Get("etag")
 	if len(s) < 2 {
 		return fmt.Errorf("Got Bad etag:%s", s)
@@ -274,11 +276,11 @@ func (p *putter) Close() (err error) {
 			p.abort()
 			return
 		}
-		defer checkClose(resp.Body, err)
 		if resp.StatusCode != 200 {
 			p.abort()
 			return newRespError(resp)
 		}
+		defer checkClose(resp.Body, err)
 
 		// S3 will return an error under a 200 as well. Instead of the
 		// CompleteMultipartUploadResult that we expect below, we might be
@@ -346,10 +348,11 @@ func (p *putter) abort() {
 		logger.Printf("Error aborting multipart upload: %v\n", err)
 		return
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 204 {
 		logger.Printf("Error aborting multipart upload: %v", newRespError(resp))
 	}
+	defer checkClose(resp.Body, err)
+
 	return
 }
 
@@ -393,10 +396,11 @@ func (p *putter) putMd5() (err error) {
 	if err != nil {
 		return
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 200 {
 		return newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
+
 	return
 }
 

--- a/putter.go
+++ b/putter.go
@@ -235,7 +235,7 @@ func (p *putter) putPart(part *part) error {
 	return nil
 }
 
-func (p *putter) Close() (err error) {
+func (p *putter) Close() error {
 	if p.closed {
 		p.abort()
 		return syscall.EINVAL
@@ -262,62 +262,23 @@ func (p *putter) Close() (err error) {
 	body, err := xml.Marshal(p.xml)
 	if err != nil {
 		p.abort()
-		return
+		return err
 	}
 
-	for retries := 0; retries < 5; retries++ {
-		b := bytes.NewReader(body)
-		v := url.Values{}
-		v.Set("uploadId", p.UploadID)
-
-		var resp *http.Response
-		resp, err = p.retryRequest("POST", p.url.String()+"?"+v.Encode(), b, nil)
-		if err != nil {
-			// If the connection got closed (firwall, proxy, etc.)
-			// we should also retry, just like if we'd had a 500.
-			if err == io.ErrUnexpectedEOF {
-				continue
-			}
-
-			p.abort()
-			return
-		}
-		if resp.StatusCode != 200 {
-			p.abort()
-			return newRespError(resp)
-		}
-		defer checkClose(resp.Body, err)
-
-		// S3 will return an error under a 200 as well. Instead of the
-		// CompleteMultipartUploadResult that we expect below, we might be
-		// getting an Error, e.g. with InternalError under it. We should behave
-		// in that case as though we received a 500 and try again.
-
-		p.Code = ""
-		// Parse etag from body of response
-		err = xml.NewDecoder(resp.Body).Decode(p)
-		if err != nil {
-			// The decoder unfortunately returns string error
-			// instead of specific errors.
-			if err.Error() == "unexpected EOF" {
-				continue
-			}
-
-			return
+	attemptsLeft := 5
+	for {
+		retryable, err := p.tryPut(body)
+		if err == nil {
+			// Success!
+			break
 		}
 
-		// This is what S3 returns instead of a 500 when we should try
-		// to complete the multipart upload again
-		if p.Code == "InternalError" {
-			continue
+		attemptsLeft--
+		if !retryable || attemptsLeft == 0 {
+			return err
 		}
-		// Some other generic error
-		if p.Code != "" {
-			return fmt.Errorf("CompleteMultipartUpload error: %s", p.Code)
-		}
-
-		break
 	}
+
 	// Check md5 hash of concatenated part md5 hashes against ETag
 	// more info: https://forums.aws.amazon.com/thread.jspa?messageID=456442&#456442
 	calculatedMd5ofParts := fmt.Sprintf("%x", p.md5OfParts.Sum(nil))
@@ -341,7 +302,68 @@ func (p *putter) Close() (err error) {
 			}
 		}
 	}
-	return
+	return nil
+}
+
+// tryPut makes one attempt at putting `body` via `p`. Return:
+//
+// * `false, nil` on success;
+// * `true, err` if there was a retryable error;
+// * `false, err` if there was an unretryable error.
+func (p *putter) tryPut(body []byte) (bool, error) {
+	b := bytes.NewReader(body)
+	v := url.Values{}
+	v.Set("uploadId", p.UploadID)
+
+	resp, err := p.retryRequest("POST", p.url.String()+"?"+v.Encode(), b, nil)
+	if err != nil {
+		// If the connection got closed (firwall, proxy, etc.)
+		// we should also retry, just like if we'd had a 500.
+		if err == io.ErrUnexpectedEOF {
+			return true, err
+		}
+
+		p.abort()
+		return false, err
+	}
+	if resp.StatusCode != 200 {
+		p.abort()
+		return false, newRespError(resp)
+	}
+
+	// S3 will return an error under a 200 as well. Instead of the
+	// CompleteMultipartUploadResult that we expect below, we might be
+	// getting an Error, e.g. with InternalError under it. We should behave
+	// in that case as though we received a 500 and try again.
+
+	p.Code = ""
+	// Parse etag from body of response
+	err = xml.NewDecoder(resp.Body).Decode(p)
+	closeErr := resp.Body.Close()
+	if err != nil {
+		// The decoder unfortunately returns string error
+		// instead of specific errors.
+		if err.Error() == "unexpected EOF" {
+			return true, err
+		}
+
+		return false, err
+	}
+	if closeErr != nil {
+		return true, closeErr
+	}
+
+	// This is what S3 returns instead of a 500 when we should try
+	// to complete the multipart upload again
+	if p.Code == "InternalError" {
+		return true, errors.New("S3 internal error")
+	}
+	// Some other generic error
+	if p.Code != "" {
+		return false, fmt.Errorf("CompleteMultipartUpload error: %s", p.Code)
+	}
+
+	return false, nil
 }
 
 // Try to abort multipart upload. Do not error on failure.

--- a/putter.go
+++ b/putter.go
@@ -353,7 +353,7 @@ func (p *putter) abort() {
 	if resp.StatusCode != 204 {
 		logger.Printf("Error aborting multipart upload: %v", newRespError(resp))
 	}
-	defer checkClose(resp.Body, err)
+	_ = resp.Body.Close()
 
 	return
 }

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -219,10 +219,11 @@ func (b *Bucket) delete(path string) error {
 	if err != nil {
 		return err
 	}
-	defer checkClose(resp.Body, err)
 	if resp.StatusCode != 204 {
 		return newRespError(resp)
 	}
+	defer checkClose(resp.Body, err)
+
 	return nil
 }
 

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -222,7 +222,9 @@ func (b *Bucket) delete(path string) error {
 	if resp.StatusCode != 204 {
 		return newRespError(resp)
 	}
-	defer checkClose(resp.Body, err)
+	if err := resp.Body.Close(); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/util.go
+++ b/util.go
@@ -3,7 +3,6 @@ package s3gof3r
 import (
 	"encoding/xml"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -73,14 +72,4 @@ func (e *RespError) Error() string {
 		e.StatusCode,
 		e.Message,
 	)
-}
-
-func checkClose(c io.Closer, err error) {
-	if c != nil {
-		cerr := c.Close()
-		if err == nil {
-			err = cerr
-		}
-	}
-
 }

--- a/util.go
+++ b/util.go
@@ -60,6 +60,8 @@ type RespError struct {
 	StatusCode int
 }
 
+// newRespError returns an error whose contents are based on the
+// contents of `r.Body`. It closes `r.Body`.
 func newRespError(r *http.Response) *RespError {
 	e := new(RespError)
 	e.StatusCode = r.StatusCode

--- a/util.go
+++ b/util.go
@@ -62,8 +62,8 @@ type RespError struct {
 func newRespError(r *http.Response) *RespError {
 	e := new(RespError)
 	e.StatusCode = r.StatusCode
-	xml.NewDecoder(r.Body).Decode(e) // parse error from response
-	r.Body.Close()
+	_ = xml.NewDecoder(r.Body).Decode(e) // parse error from response
+	_ = r.Body.Close()
 	return e
 }
 

--- a/util.go
+++ b/util.go
@@ -1,12 +1,9 @@
 package s3gof3r
 
 import (
-	"bytes"
-
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -65,8 +62,7 @@ type RespError struct {
 func newRespError(r *http.Response) *RespError {
 	e := new(RespError)
 	e.StatusCode = r.StatusCode
-	b, _ := ioutil.ReadAll(r.Body)
-	xml.NewDecoder(bytes.NewReader(b)).Decode(e) // parse error from response
+	xml.NewDecoder(r.Body).Decode(e) // parse error from response
 	r.Body.Close()
 	return e
 }


### PR DESCRIPTION
The main goal of this PR is to fix problems around `checkClose()` and `newRespError()` related to ensuring that `resp.Body().Close()` is called exactly once in every code path and that any errors returned when closing the body are reported back up the call stack.

The first problem was with `newRespError()`, which reads and unconditionally closes the response body. The problem is that many of its callers also closed the body themselves, often by calling `checkClose()`. It may be harmless, but the documentation doesn't specify that it's OK to call this `Close()` method twice, and the `io.Closer` interface specifically disallows it. There were also one or two places where the body wasn't closed at all.

The second problem was with the `checkClose()` function, which was broken by

    4ecf3c1 (checkClose: check for nil io.Closer, 2015-07-20)

when it was changed to take its `err` parameter as a value rather than as a pointer. This meant that its `err = cerr` only had a local effect, and _didn't_ have the desired effect of causing its caller to return an error. Therefore, many `Close()` errors would have been lost.
    
The error was compounded by the many callers who used

    defer checkClose(resp.Body, err)
    
but where `err` wasn't a named return value. Therefore, even if the pattern had been changed to

    defer checkClose(resp.Body, &err)
    
, the deferred function invocation would not have had the desired effect, because changing the local `err` variable would not have changed the caller's return value anyway.

To fix these problems, I changed the callers to do the error checking themselves and got rid of `checkClose()` entirely. It means a bit more error-handling boilerplate, but that's what Go's about, isn't it? I also made sure that callers don't call both `newRespError()` and also `resp.Body.Close()`.

The tests are not completely passing, but I think that's because of problems in the test suite that I started working on in #13.

This branch is also based on branch `go-modules` (#11) simply because I wanted to use the improved development workflow afforded by Go modules.

Note that this overlaps somewhat with #12, which I didn't know that @ccstolley was working on.

/cc @ccstolley, @carlosmn
