### PR TITLE
Really run all tests, then fix some problems thus revealed in the buffer pool

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -168,7 +168,7 @@ func (g *getter) worker() {
 
 func (g *getter) retryGetChunk(c *chunk) {
 	var err error
-	c.b = <-g.sp.get
+	c.b = g.sp.Get()
 	for i := 0; i < g.c.NTry; i++ {
 		err = g.getChunk(c)
 		if err == nil {
@@ -265,7 +265,7 @@ func (g *getter) Read(p []byte) (int, error) {
 		g.bytesRead += int64(n)
 
 		if g.cIdx >= g.rChunk.size { // chunk complete
-			g.sp.give <- g.rChunk.b
+			g.sp.Put(g.rChunk.b)
 			g.chunkID++
 			g.rChunk = nil
 		}
@@ -310,7 +310,7 @@ func (g *getter) Close() error {
 		return syscall.EINVAL
 	}
 	g.closed = true
-	close(g.sp.quit)
+	g.sp.Close()
 	close(g.quit)
 	g.cond.Broadcast()
 	if g.err != nil {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -44,7 +44,12 @@ func TestBP(t *testing.T) {
 
 	b = bp.Get()
 	bp.Put(b)
-	time.Sleep(2 * time.Millisecond)
+
+	// Give the pool time to realize that the existing buffers are
+	// older than the timeout and to free them. Yes, this is
+	// timing-dependent and therefore potentially flaky:
+	time.Sleep(5 * time.Millisecond)
+
 	if n := bp.AllocationCount(); n != 3 {
 		t.Errorf("Expected makes: %d. Actual: %d", 3, n)
 	}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -29,15 +29,15 @@ func TestBP(t *testing.T) {
 		t.Errorf("Expected buffer capacity: %d. Actual: %d", kb, cap(b))
 	}
 	bp.Put(b)
-	if bp.makes != 2 {
-		t.Errorf("Expected makes: %d. Actual: %d", 2, bp.makes)
+	if n := bp.AllocationCount(); n != 2 {
+		t.Errorf("Expected makes: %d. Actual: %d", 2, n)
 	}
 
 	b = bp.Get()
 	bp.Put(b)
 	time.Sleep(2 * time.Millisecond)
-	if bp.makes != 3 {
-		t.Errorf("Expected makes: %d. Actual: %d", 3, bp.makes)
+	if n := bp.AllocationCount(); n != 3 {
+		t.Errorf("Expected makes: %d. Actual: %d", 3, n)
 	}
 	bp.Close()
 	expLog := "3 buffers of 1 MB allocated"

--- a/pool.go
+++ b/pool.go
@@ -16,7 +16,6 @@ type bp struct {
 	give    chan []byte
 	quit    chan struct{}
 	timeout time.Duration
-	bufsz   int64
 	sizech  chan int64
 }
 

--- a/pool.go
+++ b/pool.go
@@ -67,3 +67,19 @@ func bufferPool(bufsz int64) (sp *bp) {
 	}()
 	return sp
 }
+
+func (bp *bp) Get() []byte {
+	return <-bp.get
+}
+
+func (bp *bp) Put(buf []byte) {
+	bp.give <- buf
+}
+
+func (bp *bp) Close() {
+	close(bp.quit)
+}
+
+func (bp *bp) SetBufferSize(bufsz int64) {
+	bp.sizech <- bufsz
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -21,22 +21,22 @@ func TestBP(t *testing.T) {
 
 	bp := bufferPool(mb)
 	bp.timeout = 1 * time.Millisecond
-	b := <-bp.get
+	b := bp.Get()
 	if cap(b) != int(mb) {
 		t.Errorf("Expected buffer capacity: %d. Actual: %d", kb, cap(b))
 	}
-	bp.give <- b
+	bp.Put(b)
 	if bp.makes != 2 {
 		t.Errorf("Expected makes: %d. Actual: %d", 2, bp.makes)
 	}
 
-	b = <-bp.get
-	bp.give <- b
+	b = bp.Get()
+	bp.Put(b)
 	time.Sleep(2 * time.Millisecond)
 	if bp.makes != 3 {
 		t.Errorf("Expected makes: %d. Actual: %d", 3, bp.makes)
 	}
-	close(bp.quit)
+	bp.Close()
 	expLog := "3 buffers of 1 MB allocated"
 	time.Sleep(1 * time.Millisecond) // wait for log
 	ls := lf.String()

--- a/putter.go
+++ b/putter.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/github/s3gof3r/internal/pool"
 )
 
 // defined by amazon
@@ -64,7 +66,7 @@ type putter struct {
 	ETag       string
 	Code       string
 
-	sp *bp
+	sp *pool.BufferPool
 
 	makes    int
 	UploadID string `xml:"UploadId"`
@@ -106,7 +108,7 @@ func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (p *putter, err
 	p.md5OfParts = md5.New()
 	p.md5 = md5.New()
 
-	p.sp = bufferPool(p.bufsz)
+	p.sp = pool.NewBufferPool(bufferPoolLogger{}, p.bufsz)
 
 	return p, nil
 }

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("creating test bucket: %v", err)
 	}
 	uploadTestFiles()
+	os.Exit(m.Run())
 }
 
 func uploadTestFiles() {

--- a/util.go
+++ b/util.go
@@ -86,3 +86,9 @@ func checkClose(c io.Closer, err error) {
 	}
 
 }
+
+type bufferPoolLogger struct{}
+
+func (l bufferPoolLogger) Printf(format string, a ...interface{}) {
+	logger.debugPrintf(format, a...)
+}


### PR DESCRIPTION
In #13 I missed an important incantation in the `TestMain()` function, meaning that the tests in the root directory were still not being executed. This PR fixes that…

…which reveals a breakage in the "pool" type. So the rest of this PR is moving that type into its own internal package, fixing the problem (which was that the pool would unnecessarily allocate and free buffers every time the timeout expired), and fixing some other data races. After these changes, the tests for the pool type (now called `BufferPool`) run without errors, even with `-race` turned on.

This branch is intentionally based on the main branch commit just after #13 was merged, to give a good starting point for comparison. Now I have to revisit my other PRs to see if the tests are still passing after this fix.

This series is written to be readable commit-by-commit.

/cc @ccstolley, @carlosmn
