### PR TITLE
Abstract out an S3 client for the use of `putter`

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/github/s3gof3r/internal/s3client"
 )
 
 // Keys for an Amazon Web Services account.
@@ -40,7 +42,7 @@ func InstanceKeys() (Keys, error) {
 		return Keys{}, err
 	}
 	if resp.StatusCode != 200 {
-		return Keys{}, newRespError(resp)
+		return Keys{}, s3client.NewRespError(resp)
 	}
 
 	role, err := ioutil.ReadAll(resp.Body)
@@ -58,7 +60,7 @@ func InstanceKeys() (Keys, error) {
 		return Keys{}, err
 	}
 	if resp.StatusCode != 200 {
-		return Keys{}, newRespError(resp)
+		return Keys{}, s3client.NewRespError(resp)
 	}
 
 	metadata, err := ioutil.ReadAll(resp.Body)

--- a/delete_multiple.go
+++ b/delete_multiple.go
@@ -7,6 +7,8 @@ import (
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/github/s3gof3r/internal/s3client"
 )
 
 type deleteObject struct {
@@ -73,7 +75,7 @@ func deleteMultiple(c *Config, b *Bucket, quiet bool, keys []string) (DeleteResu
 		ContentLength: int64(len(body)),
 		Header:        make(http.Header),
 	}
-	r.Header.Set(md5Header, base64.StdEncoding.EncodeToString(md5sum[:]))
+	r.Header.Set(s3client.MD5Header, base64.StdEncoding.EncodeToString(md5sum[:]))
 	b.Sign(&r)
 
 	resp, err := b.conf().Do(&r)
@@ -81,7 +83,7 @@ func deleteMultiple(c *Config, b *Bucket, quiet bool, keys []string) (DeleteResu
 		return DeleteResult{}, err
 	}
 	if resp.StatusCode != 200 {
-		return DeleteResult{}, newRespError(resp)
+		return DeleteResult{}, s3client.NewRespError(resp)
 	}
 
 	var result DeleteResult

--- a/internal/s3client/error.go
+++ b/internal/s3client/error.go
@@ -1,0 +1,35 @@
+package s3client
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+)
+
+// RespError represents an http error response
+// http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+type RespError struct {
+	Code       string
+	Message    string
+	Resource   string
+	RequestID  string `xml:"RequestId"`
+	StatusCode int
+}
+
+// NewRespError returns an error whose contents are based on the
+// contents of `r.Body`. It closes `r.Body`.
+func NewRespError(r *http.Response) *RespError {
+	e := new(RespError)
+	e.StatusCode = r.StatusCode
+	_ = xml.NewDecoder(r.Body).Decode(e) // parse error from response
+	_ = r.Body.Close()
+	return e
+}
+
+func (e *RespError) Error() string {
+	return fmt.Sprintf(
+		"%d: %q",
+		e.StatusCode,
+		e.Message,
+	)
+}

--- a/internal/s3client/s3client.go
+++ b/internal/s3client/s3client.go
@@ -63,7 +63,8 @@ func (c *Client) StartMultipartUpload(h http.Header) (string, error) {
 		return "", err
 	}
 	if closeErr != nil {
-		return r.UploadID, closeErr
+		_ = c.AbortMultipartUpload(r.UploadID)
+		return "", closeErr
 	}
 	return r.UploadID, nil
 }

--- a/internal/s3client/s3client.go
+++ b/internal/s3client/s3client.go
@@ -322,6 +322,7 @@ func (c *Client) retryRequest(
 		c.signer.Sign(req)
 		resp, err := c.httpClient.Do(req)
 		if err == nil && resp.StatusCode == 500 {
+			_ = resp.Body.Close()
 			err = err500
 			// Exponential back-off:
 			time.Sleep(time.Duration(math.Exp2(float64(attempt))) * 100 * time.Millisecond)

--- a/list_objects.go
+++ b/list_objects.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/github/s3gof3r/internal/s3client"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -250,7 +251,7 @@ func listObjects(c *Config, b *Bucket, opts listObjectsOptions) (*listBucketResu
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, newRespError(resp)
+		return nil, s3client.NewRespError(resp)
 	}
 
 	err = xml.NewDecoder(resp.Body).Decode(result)

--- a/putter.go
+++ b/putter.go
@@ -28,11 +28,19 @@ const (
 	maxNPart    = 10000
 )
 
+type s3Putter interface {
+	StartMultipartUpload(h http.Header) (string, error)
+	UploadPart(uploadID string, part *s3client.Part) error
+	CompleteMultipartUpload(uploadID string, parts []*s3client.Part) (string, error)
+	AbortMultipartUpload(uploadID string) error
+	PutMD5(url *url.URL, md5 string) error
+}
+
 type putter struct {
 	url    url.URL
 	b      *Bucket
 	c      *Config
-	client *s3client.Client
+	client s3Putter
 
 	bufsz      int64
 	buf        []byte

--- a/putter.go
+++ b/putter.go
@@ -213,21 +213,12 @@ func (p *putter) Close() error {
 		return p.err
 	}
 
-	attemptsLeft := 5
-	for {
-		eTag, retryable, err := p.client.completeMultipartUpload(p.uploadID, p.parts)
-		if err == nil {
-			// Success!
-			p.eTag = eTag
-			break
-		}
-
-		attemptsLeft--
-		if !retryable || attemptsLeft == 0 {
-			p.abort()
-			return err
-		}
+	eTag, err := p.client.CompleteMultipartUpload(p.uploadID, p.parts)
+	if err != nil {
+		p.abort()
+		return err
 	}
+	p.eTag = eTag
 
 	if err := p.checkMd5sOfParts(); err != nil {
 		return err

--- a/putter.go
+++ b/putter.go
@@ -367,20 +367,28 @@ func (p *putter) completeMultipartUpload() (bool, error) {
 
 // Try to abort multipart upload. Do not error on failure.
 func (p *putter) abort() {
+	err := p.abortMultipartUpload()
+	if err != nil {
+		logger.Printf("Error aborting multipart upload: %v\n", err)
+	}
+}
+
+// abortMultipartUpload aborts the multipart upload represented by
+// `p`, discarding any partly-uploaded contents.
+func (p *putter) abortMultipartUpload() error {
 	v := url.Values{}
 	v.Set("uploadId", p.uploadID)
 	s := p.url.String() + "?" + v.Encode()
 	resp, err := p.retryRequest("DELETE", s, nil, nil)
 	if err != nil {
-		logger.Printf("Error aborting multipart upload: %v\n", err)
-		return
+		return err
 	}
 	if resp.StatusCode != 204 {
-		logger.Printf("Error aborting multipart upload: %v", newRespError(resp))
+		return newRespError(resp)
 	}
 	_ = resp.Body.Close()
 
-	return
+	return nil
 }
 
 // Md5 functions

--- a/putter.go
+++ b/putter.go
@@ -64,7 +64,6 @@ type putter struct {
 
 	sp *pool.BufferPool
 
-	makes    int
 	uploadID string
 	parts    []*part
 	putsz    int64

--- a/putter.go
+++ b/putter.go
@@ -185,7 +185,7 @@ func (p *putter) retryPutPart(part *part) {
 	defer p.wg.Done()
 	var err error
 	for i := 0; i < p.c.NTry; i++ {
-		err = p.putPart(part)
+		err = p.uploadPart(part)
 		if err == nil {
 			// Give the buffer back to the pool, first making sure
 			// that its length is set to its full capacity:
@@ -201,7 +201,7 @@ func (p *putter) retryPutPart(part *part) {
 }
 
 // uploads a part, checking the etag against the calculated value
-func (p *putter) putPart(part *part) error {
+func (p *putter) uploadPart(part *part) error {
 	v := url.Values{}
 	v.Set("partNumber", strconv.Itoa(part.PartNumber))
 	v.Set("uploadId", p.uploadID)

--- a/putter.go
+++ b/putter.go
@@ -61,7 +61,7 @@ type putter struct {
 	wg         sync.WaitGroup
 	md5OfParts hash.Hash
 	md5        hash.Hash
-	ETag       string
+	eTag       string
 
 	sp *pool.BufferPool
 
@@ -229,7 +229,7 @@ func (p *putter) uploadPart(part *part) error {
 	}
 	s = s[1 : len(s)-1] // includes quote chars for some reason
 	if part.ETag != s {
-		return fmt.Errorf("Response etag does not match. Remote:%s Calculated:%s", s, p.ETag)
+		return fmt.Errorf("Response etag does not match. Remote:%s Calculated:%s", s, p.eTag)
 	}
 	return nil
 }
@@ -277,7 +277,7 @@ func (p *putter) Close() error {
 	// more info: https://forums.aws.amazon.com/thread.jspa?messageID=456442&#456442
 	calculatedMd5ofParts := fmt.Sprintf("%x", p.md5OfParts.Sum(nil))
 	// Strip part count from end:
-	remoteMd5ofParts := p.ETag
+	remoteMd5ofParts := p.eTag
 	remoteMd5ofParts = strings.Split(remoteMd5ofParts, "-")[0]
 	if len(remoteMd5ofParts) == 0 {
 		return fmt.Errorf("Nil ETag")
@@ -364,7 +364,7 @@ func (p *putter) completeMultipartUpload() (bool, error) {
 		return false, fmt.Errorf("CompleteMultipartUpload error: %s", r.Code)
 	}
 
-	p.ETag = strings.Trim(r.ETag, "\"")
+	p.eTag = strings.Trim(r.ETag, "\"")
 
 	return false, nil
 }

--- a/putter.go
+++ b/putter.go
@@ -231,11 +231,8 @@ func (p *putter) Close() error {
 		sum := fmt.Sprintf("%x", p.md5.Sum(nil))
 		logger.debugPrintln("md5: ", sum)
 		logger.debugPrintln("md5Path: ", md5Path)
-		for i := 0; i < p.c.NTry; i++ {
-			if err := p.client.putMD5(md5URL, sum); err == nil {
-				break
-			}
-		}
+		// FIXME: should this error really be ignored?
+		_ = p.client.PutMD5(md5URL, sum)
 	}
 	return nil
 }

--- a/putter.go
+++ b/putter.go
@@ -276,8 +276,8 @@ func (p *putter) Close() error {
 	// Check md5 hash of concatenated part md5 hashes against ETag
 	// more info: https://forums.aws.amazon.com/thread.jspa?messageID=456442&#456442
 	calculatedMd5ofParts := fmt.Sprintf("%x", p.md5OfParts.Sum(nil))
-	// Trim quotes '"' and strip part count from end.
-	remoteMd5ofParts := strings.Trim(p.ETag, "\"")
+	// Strip part count from end:
+	remoteMd5ofParts := p.ETag
 	remoteMd5ofParts = strings.Split(remoteMd5ofParts, "-")[0]
 	if len(remoteMd5ofParts) == 0 {
 		return fmt.Errorf("Nil ETag")
@@ -364,7 +364,7 @@ func (p *putter) completeMultipartUpload() (bool, error) {
 		return false, fmt.Errorf("CompleteMultipartUpload error: %s", r.Code)
 	}
 
-	p.ETag = r.ETag
+	p.ETag = strings.Trim(r.ETag, "\"")
 
 	return false, nil
 }

--- a/putter.go
+++ b/putter.go
@@ -290,9 +290,6 @@ func (p *putter) Close() error {
 		return fmt.Errorf("Nil ETag")
 	}
 	if calculatedMd5ofParts != remoteMd5ofParts {
-		if err != nil {
-			return err
-		}
 		return fmt.Errorf("MD5 hash of part hashes comparison failed. Hash from multipart complete header: %s."+
 			" Calculated multipart hash: %s.", remoteMd5ofParts, calculatedMd5ofParts)
 	}

--- a/putter.go
+++ b/putter.go
@@ -259,28 +259,10 @@ func (p *putter) checkMd5sOfParts() error {
 
 // Try to abort multipart upload. Do not error on failure.
 func (p *putter) abort() {
-	err := p.abortMultipartUpload()
+	err := p.client.AbortMultipartUpload(p.uploadID)
 	if err != nil {
 		logger.Printf("Error aborting multipart upload: %v\n", err)
 	}
-}
-
-// abortMultipartUpload aborts the multipart upload represented by
-// `p`, discarding any partly-uploaded contents.
-func (p *putter) abortMultipartUpload() error {
-	v := url.Values{}
-	v.Set("uploadId", p.uploadID)
-	s := p.url.String() + "?" + v.Encode()
-	resp, err := p.retryRequest("DELETE", s, nil, nil)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 204 {
-		return newRespError(resp)
-	}
-	_ = resp.Body.Close()
-
-	return nil
 }
 
 // Md5 functions

--- a/putter.go
+++ b/putter.go
@@ -275,6 +275,7 @@ func (p *putter) Close() error {
 
 		attemptsLeft--
 		if !retryable || attemptsLeft == 0 {
+			p.abort()
 			return err
 		}
 	}

--- a/s3client.go
+++ b/s3client.go
@@ -1,0 +1,96 @@
+package s3gof3r
+
+import (
+	"encoding/xml"
+	"errors"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// client is a client that encapsules low-level interactions with a
+// specific, single blob.
+type client struct {
+	url        url.URL
+	bucket     *Bucket
+	httpClient *http.Client // http client to use for requests
+	nTry       int
+}
+
+func newClient(
+	url url.URL, bucket *Bucket, httpClient *http.Client, nTry int,
+) *client {
+	c := client{
+		url:        url,
+		bucket:     bucket,
+		httpClient: httpClient,
+		nTry:       nTry,
+	}
+	return &c
+}
+
+func (c *client) StartMultipartUpload(h http.Header) (string, error) {
+	resp, err := c.retryRequest("POST", c.url.String()+"?uploads", nil, h)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 200 {
+		return "", newRespError(resp)
+	}
+
+	var r struct {
+		UploadID string `xml:"UploadId"`
+	}
+
+	err = xml.NewDecoder(resp.Body).Decode(&r)
+	closeErr := resp.Body.Close()
+	if err != nil {
+		return "", err
+	}
+	if closeErr != nil {
+		return r.UploadID, closeErr
+	}
+	return r.UploadID, nil
+}
+
+var err500 = errors.New("received 500 from server")
+
+func (c *client) retryRequest(
+	method, urlStr string, body io.ReadSeeker, h http.Header,
+) (resp *http.Response, err error) {
+	for i := 0; i < c.nTry; i++ {
+		var req *http.Request
+		req, err = http.NewRequest(method, urlStr, body)
+		if err != nil {
+			return
+		}
+		for k := range h {
+			for _, v := range h[k] {
+				req.Header.Add(k, v)
+			}
+		}
+
+		if body != nil {
+			req.Header.Set(sha256Header, shaReader(body))
+		}
+
+		c.bucket.Sign(req)
+		resp, err = c.httpClient.Do(req)
+		if err == nil && resp.StatusCode == 500 {
+			err = err500
+			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
+		}
+		if err == nil {
+			return
+		}
+		logger.debugPrintln(err)
+		if body != nil {
+			if _, err = body.Seek(0, 0); err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/s3client.go
+++ b/s3client.go
@@ -218,6 +218,24 @@ func (c *client) completeMultipartUpload(uploadID string, parts []*part) (string
 	return strings.Trim(r.ETag, "\""), false, nil
 }
 
+// AbortMultipartUpload aborts a multipart upload, discarding any
+// partly-uploaded contents.
+func (c *client) AbortMultipartUpload(uploadID string) error {
+	v := url.Values{}
+	v.Set("uploadId", uploadID)
+	s := c.url.String() + "?" + v.Encode()
+	resp, err := c.retryRequest("DELETE", s, nil, nil)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 204 {
+		return newRespError(resp)
+	}
+	_ = resp.Body.Close()
+
+	return nil
+}
+
 var err500 = errors.New("received 500 from server")
 
 func (c *client) retryRequest(

--- a/s3client.go
+++ b/s3client.go
@@ -236,10 +236,21 @@ func (c *client) AbortMultipartUpload(uploadID string) error {
 	return nil
 }
 
-// PutMD5 writes an md5 file in a ".md5" subdirectory of the directory
-// where the blob is stored; e.g., the md5 for blob
-// https://mybucket.s3.amazonaws.com/gof3r will be stored in
-// https://mybucket.s3.amazonaws.com/.md5/gof3r.md5.
+// PutMD5 attempts to write an md5 file in a ".md5" subdirectory of
+// the directory where the blob is stored, with retries. For example,
+// the md5 for blob https://mybucket.s3.amazonaws.com/gof3r will be
+// stored in https://mybucket.s3.amazonaws.com/.md5/gof3r.md5.
+func (c *client) PutMD5(url *url.URL, md5 string) error {
+	var err error
+	for i := 0; i < c.nTry; i++ {
+		err = c.putMD5(url, md5)
+		if err == nil {
+			break
+		}
+	}
+	return err
+}
+
 // putMD5 makes one attempt to write an md5 file in a ".md5"
 // subdirectory of the directory where the blob is stored; e.g., the
 // md5 for blob https://mybucket.s3.amazonaws.com/gof3r will be stored

--- a/s3client.go
+++ b/s3client.go
@@ -114,6 +114,25 @@ func (c *client) uploadPartAttempt(uploadID string, part *part) error {
 	return nil
 }
 
+// CompleteMultipartUpload completes a multiline upload, using
+// `parts`, which have been uploaded already. Retry on errors. On
+// success, return the etag that was returned by S3.
+func (c *client) CompleteMultipartUpload(uploadID string, parts []*part) (string, error) {
+	attemptsLeft := 5
+	for {
+		eTag, retryable, err := c.completeMultipartUpload(uploadID, parts)
+		if err == nil {
+			// Success!
+			return eTag, nil
+		}
+
+		attemptsLeft--
+		if !retryable || attemptsLeft == 0 {
+			return "", err
+		}
+	}
+}
+
 // completeMultipartUpload makes one attempt at completing a multiline
 // upload, using `parts`, which have been uploaded already. Return:
 //

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -14,6 +14,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/github/s3gof3r/internal/s3client"
 )
 
 const versionParam = "versionId"
@@ -220,7 +222,7 @@ func (b *Bucket) delete(path string) error {
 		return err
 	}
 	if resp.StatusCode != 204 {
-		return newRespError(resp)
+		return s3client.NewRespError(resp)
 	}
 	if err := resp.Body.Close(); err != nil {
 		return err

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/github/s3gof3r/internal/s3client"
 )
 
 var b *tB
@@ -60,7 +62,7 @@ var getTests = []struct {
 }{
 	{"t1.test", nil, 1 * kb, nil},
 	{"no-md5", &Config{Scheme: "https", Client: ClientWithTimeout(clientTimeout), Md5Check: false}, 1, nil},
-	{"NoKey", nil, -1, &RespError{StatusCode: 404, Message: "The specified key does not exist."}},
+	{"NoKey", nil, -1, &s3client.RespError{StatusCode: 404, Message: "The specified key does not exist."}},
 	{"", nil, -1, fmt.Errorf("empty path requested")},
 	{"1_mb_test",
 		&Config{Concurrency: 2, PartSize: 5 * mb, NTry: 2, Md5Check: true, Scheme: "https", Client: ClientWithTimeout(2 * time.Second)},
@@ -108,11 +110,11 @@ func TestPutWriter(t *testing.T) {
 	}{
 		{"testfile", []byte("test_data"), nil, nil, 9, nil},
 		{"", []byte("test_data"), nil, nil,
-			9, &RespError{StatusCode: 400, Message: "A key must be specified"}},
+			9, &s3client.RespError{StatusCode: 400, Message: "A key must be specified"}},
 		{"test0byte", []byte(""), nil, nil, 0, nil},
 		{"testhg", []byte("foo"), goodHeader(), nil, 3, nil},
 		{"testhb", []byte("foo"), badHeader(), nil, 3,
-			&RespError{StatusCode: 400, Message: "The encryption method specified is not supported"}},
+			&s3client.RespError{StatusCode: 400, Message: "The encryption method specified is not supported"}},
 		{"nomd5", []byte("foo"), goodHeader(),
 			&Config{Concurrency: 1, PartSize: 5 * mb, NTry: 1, Md5Check: false, Scheme: "http", Client: http.DefaultClient}, 3, nil},
 		{"noconc", []byte("foo"), nil,

--- a/sign.go
+++ b/sign.go
@@ -5,7 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"sort"
@@ -182,14 +181,4 @@ func sha(data []byte) []byte {
 	hash := sha256.New()
 	hash.Write(data)
 	return hash.Sum(nil)
-}
-
-func shaReader(r io.ReadSeeker) string {
-	hash := sha256.New()
-	start, _ := r.Seek(0, 1)
-	defer r.Seek(start, 0)
-
-	io.Copy(hash, r)
-	sum := hash.Sum(nil)
-	return hex.EncodeToString(sum)
 }

--- a/util.go
+++ b/util.go
@@ -1,11 +1,5 @@
 package s3gof3r
 
-import (
-	"encoding/xml"
-	"fmt"
-	"net/http"
-)
-
 // convenience multipliers
 const (
 	_        = iota
@@ -44,34 +38,6 @@ func max64(a, b int64) int64 {
 		return a
 	}
 	return b
-}
-
-// RespError representbs an http error response
-// http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
-type RespError struct {
-	Code       string
-	Message    string
-	Resource   string
-	RequestID  string `xml:"RequestId"`
-	StatusCode int
-}
-
-// newRespError returns an error whose contents are based on the
-// contents of `r.Body`. It closes `r.Body`.
-func newRespError(r *http.Response) *RespError {
-	e := new(RespError)
-	e.StatusCode = r.StatusCode
-	_ = xml.NewDecoder(r.Body).Decode(e) // parse error from response
-	_ = r.Body.Close()
-	return e
-}
-
-func (e *RespError) Error() string {
-	return fmt.Sprintf(
-		"%d: %q",
-		e.StatusCode,
-		e.Message,
-	)
 }
 
 type bufferPoolLogger struct{}


### PR DESCRIPTION
Separate out the code in `putter` that actually talks to S3 into a separate internal type, `s3client.Client`. This makes it easier to see the (concurrency) forest among all the (http) trees. Additionally, avoid splatting XML into domain-level data structures; instead, use isolated types to capture XML data.

Fix a couple of bugs along the way:

* Don't forget to abort the upload (and delete partial uploads) if the `CompleteMultipartUpload` step fails.
* Fix a segfault that would occur if all `NTry` attempts failed within `retryRequest()` when a body was also provided.
* Don't forget to close the response body in `retryRequest()` in the case of a 500 error.

This PR is written so that it can be read commit-by-commit. It is based on the `really-run-all-tests` branch (aka #16), even though that PR is still waiting on review (hint, hint).

/cc @ccstolley , @carlosmn 
