### PR TITLE
Renovate `putter` and remove some data races

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -20,7 +20,7 @@ import (
 const qWaitMax = 2
 
 type getter struct {
-	url   url.URL
+	url   *url.URL
 	b     *Bucket
 	bufsz int64
 	err   error
@@ -59,7 +59,7 @@ type chunk struct {
 	b      []byte
 }
 
-func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header, error) {
+func newGetter(getURL *url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header, error) {
 	g := new(getter)
 	g.url = getURL
 	g.c, g.b = new(Config), new(Bucket)

--- a/getter.go
+++ b/getter.go
@@ -62,11 +62,10 @@ type chunk struct {
 func newGetter(getURL *url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header, error) {
 	g := new(getter)
 	g.url = getURL
-	g.c, g.b = new(Config), new(Bucket)
-	*g.c, *g.b = *c, *b
-	g.bufsz = max64(c.PartSize, 1)
-	g.c.NTry = max(c.NTry, 1)
-	g.c.Concurrency = max(c.Concurrency, 1)
+	g.b = new(Bucket)
+	*g.b = *b
+	g.c = c.safeCopy(1)
+	g.bufsz = g.c.PartSize
 
 	g.getCh = make(chan *chunk)
 	g.readCh = make(chan *chunk)

--- a/getter_test.go
+++ b/getter_test.go
@@ -19,7 +19,7 @@ func NewFakeGetter(testurl string) (io.ReadCloser, error) {
 	}
 	c := b.conf()
 	c.NTry = 1
-	g, _, err := newGetter(*u, c, b)
+	g, _, err := newGetter(u, c, b)
 	if err != nil {
 		return nil, fmt.Errorf("newGetter() %s", err)
 	}

--- a/internal/s3client/s3client.go
+++ b/internal/s3client/s3client.go
@@ -25,6 +25,7 @@ const (
 // specific, single blob.
 type Client struct {
 	url        *url.URL
+	md5URL     *url.URL
 	signer     signer
 	httpClient *http.Client // http client to use for requests
 	nTry       int
@@ -32,10 +33,11 @@ type Client struct {
 }
 
 func New(
-	url *url.URL, signer signer, httpClient *http.Client, nTry int, logger logger,
+	url, md5URL *url.URL, signer signer, httpClient *http.Client, nTry int, logger logger,
 ) *Client {
 	c := Client{
 		url:        url,
+		md5URL:     md5URL,
 		signer:     signer,
 		httpClient: httpClient,
 		nTry:       nTry,
@@ -262,10 +264,12 @@ func (c *Client) AbortMultipartUpload(uploadID string) error {
 // the directory where the blob is stored, with retries. For example,
 // the md5 for blob https://mybucket.s3.amazonaws.com/gof3r will be
 // stored in https://mybucket.s3.amazonaws.com/.md5/gof3r.md5.
-func (c *Client) PutMD5(url *url.URL, md5 string) error {
+func (c *Client) PutMD5(sum string) error {
+	c.logger.Printf("md5: %s", sum)
+	c.logger.Printf("md5Path: %s", c.md5URL.Path)
 	var err error
 	for i := 0; i < c.nTry; i++ {
-		err = c.putMD5(url, md5)
+		err = c.putMD5(sum)
 		if err == nil {
 			break
 		}
@@ -277,10 +281,10 @@ func (c *Client) PutMD5(url *url.URL, md5 string) error {
 // subdirectory of the directory where the blob is stored; e.g., the
 // md5 for blob https://mybucket.s3.amazonaws.com/gof3r will be stored
 // in https://mybucket.s3.amazonaws.com/.md5/gof3r.md5.
-func (c *Client) putMD5(url *url.URL, md5 string) error {
+func (c *Client) putMD5(md5 string) error {
 	md5Reader := strings.NewReader(md5)
 
-	r, err := http.NewRequest("PUT", url.String(), md5Reader)
+	r, err := http.NewRequest("PUT", c.md5URL.String(), md5Reader)
 	if err != nil {
 		return err
 	}

--- a/internal/s3client/s3client.go
+++ b/internal/s3client/s3client.go
@@ -24,7 +24,7 @@ const (
 // Client is a Client that encapsules low-level interactions with a
 // specific, single blob.
 type Client struct {
-	url        url.URL
+	url        *url.URL
 	signer     signer
 	httpClient *http.Client // http client to use for requests
 	nTry       int
@@ -32,7 +32,7 @@ type Client struct {
 }
 
 func New(
-	url url.URL, signer signer, httpClient *http.Client, nTry int, logger logger,
+	url *url.URL, signer signer, httpClient *http.Client, nTry int, logger logger,
 ) *Client {
 	c := Client{
 		url:        url,

--- a/putter.go
+++ b/putter.go
@@ -113,7 +113,7 @@ type putter struct {
 // The initial request returns an UploadId that we use to identify
 // subsequent PUT requests.
 func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (*putter, error) {
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 
 	cCopy := *c

--- a/putter.go
+++ b/putter.go
@@ -87,7 +87,7 @@ type s3Putter interface {
 type putter struct {
 	cancel context.CancelFunc
 
-	url    url.URL
+	url    *url.URL
 	b      *Bucket
 	c      *Config
 	client s3Putter
@@ -112,7 +112,7 @@ type putter struct {
 // See http://docs.amazonwebservices.com/AmazonS3/latest/dev/mpuoverview.html.
 // The initial request returns an UploadId that we use to identify
 // subsequent PUT requests.
-func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (*putter, error) {
+func newPutter(url *url.URL, h http.Header, c *Config, b *Bucket) (*putter, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/putter.go
+++ b/putter.go
@@ -87,7 +87,6 @@ type s3Putter interface {
 type putter struct {
 	cancel context.CancelFunc
 
-	url    *url.URL
 	c      *Config
 	client s3Putter
 
@@ -118,7 +117,6 @@ func newPutter(blobURL *url.URL, h http.Header, c *Config, b *Bucket) (*putter, 
 	c = c.safeCopy(minPartSize)
 	p := putter{
 		cancel:     cancel,
-		url:        blobURL,
 		c:          c,
 		bufsz:      c.PartSize,
 		eg:         eg,
@@ -128,7 +126,7 @@ func newPutter(blobURL *url.URL, h http.Header, c *Config, b *Bucket) (*putter, 
 
 	var md5URL *url.URL
 	if p.c.Md5Check {
-		md5Path := fmt.Sprint(".md5", p.url.Path, ".md5")
+		md5Path := fmt.Sprint(".md5", blobURL.Path, ".md5")
 		var err error
 		md5URL, err = b.url(md5Path, p.c)
 		if err != nil {
@@ -136,7 +134,7 @@ func newPutter(blobURL *url.URL, h http.Header, c *Config, b *Bucket) (*putter, 
 		}
 	}
 
-	p.client = s3client.New(p.url, md5URL, b, p.c.Client, p.c.NTry, bufferPoolLogger{})
+	p.client = s3client.New(blobURL, md5URL, b, p.c.Client, p.c.NTry, bufferPoolLogger{})
 
 	var err error
 	p.uploadID, err = p.client.StartMultipartUpload(h)

--- a/putter.go
+++ b/putter.go
@@ -193,8 +193,8 @@ func (p *putter) Close() error {
 		len(p.parts) == 0 { // 0 length file
 		p.flush()
 	}
-	p.wg.Wait()
 	close(p.ch)
+	p.wg.Wait()
 	p.closed = true
 	p.sp.Close()
 

--- a/putter.go
+++ b/putter.go
@@ -167,26 +167,17 @@ func (p *putter) addPart(buf []byte) (*s3client.Part, error) {
 
 func (p *putter) worker() {
 	for part := range p.ch {
-		err := p.retryPutPart(part)
+		err := p.client.UploadPart(p.uploadID, part)
 		if err != nil {
 			p.err = err
 		}
-	}
-}
 
-// Upload `part` to S3 and handle errors.
-func (p *putter) retryPutPart(part *s3client.Part) error {
-	defer p.wg.Done()
-	err := p.client.UploadPart(p.uploadID, part)
-	if err != nil {
-		return err
+		// Give the buffer back to the pool, first making sure
+		// that its length is set to its full capacity:
+		p.sp.Put(part.Data[:cap(part.Data)])
+		part.Data = nil
+		p.wg.Done()
 	}
-
-	// Give the buffer back to the pool, first making sure
-	// that its length is set to its full capacity:
-	p.sp.Put(part.Data[:cap(part.Data)])
-	part.Data = nil
-	return nil
 }
 
 func (p *putter) Close() error {

--- a/putter.go
+++ b/putter.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/github/s3gof3r/internal/pool"
 	"github.com/github/s3gof3r/internal/s3client"
+	"golang.org/x/sync/errgroup"
 )
 
 // defined by amazon
@@ -37,6 +39,51 @@ type s3Putter interface {
 	PutMD5(url *url.URL, md5 string) error
 }
 
+// putter is an `io.Writer` that uploads the data written to it to an
+// S3 blob.
+//
+// Data flow for data written via `putter.Write()`:
+//
+//                                                                receive          putPart()
+//                                                                      +----------+     +----+
+//                                                                    > | worker() | --> | S3 |
+//            p.pw.Write()      pr.Read()             send           /  +----------+     +----+
+//     +--------+     +---------+     +--------------+     +------+ /   +----------+     +----+
+//     | caller | --> | io.Pipe | --> | queueParts() | --> | p.ch | --> | worker() | --> | S3 |
+//     +--------+     +---------+     +--------------+     +------+ \   +----------+     +----+
+//                                          |                        \  +----------+     +----+
+//                                          |                         > | worker() | --> | S3 |
+//                                     hashContent()                    +----------+     +----+
+//                                          |
+//                                          v
+//                                      +-------+                Close()                 +----+
+//                                      | p.xml | -------------------------------------> | S3 |
+//                                      +-------+                                        +----+
+//
+// The normal shutdown sequence:
+//
+// * The caller invokes `p.Close()`.
+//
+// * This closes `p.pr`, the write end of the pipe, which causes
+//   `queueParts()` to read an EOF and return.
+//
+// * The `queueParts()` goroutine closes the read end of the pipe
+//   (which makes any future calls to `p.Write()` fail) and closes
+//   `p.ch`.
+//
+// * The closure of `p.ch` causes the `worker()` invocations to
+//   return.
+//
+// * When all of the above goroutines finish, `p.eg.Wait()` returns,
+//   allowing the `CompleteMultipartUpload` step to proceed.
+//
+// If an error occurs in one of the goroutines, the goroutine returns
+// an error, which causes the `errgroup.Group` to cancel its context,
+// causing most of the other goroutines to exit promptly. The only
+// tricky one is `queueParts()`, which might be blocked reading from
+// the read end of the pipe. So an extra goroutine waits on
+// `ctx.Done()` and then closes the write end of the pipe if it hasn't
+// already been closed by `p.Close()`.
 type putter struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -46,13 +93,12 @@ type putter struct {
 	c      *Config
 	client s3Putter
 
+	pw *io.PipeWriter
+
 	bufsz      int64
-	buf        []byte
-	bufbytes   int // bytes written to current buffer
 	ch         chan *s3client.Part
-	closed     bool
-	err        error
-	wg         sync.WaitGroup
+	closeOnce  sync.Once
+	eg         *errgroup.Group
 	md5OfParts hash.Hash
 	md5        hash.Hash
 	eTag       string
@@ -70,6 +116,7 @@ type putter struct {
 // subsequent PUT requests.
 func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (*putter, error) {
 	ctx, cancel := context.WithCancel(context.TODO())
+	eg, ctx := errgroup.WithContext(ctx)
 
 	cCopy := *c
 	cCopy.Concurrency = max(c.Concurrency, 1)
@@ -84,6 +131,7 @@ func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (*putter, error
 		b:          &bCopy,
 		bufsz:      bufsz,
 		ch:         make(chan *s3client.Part),
+		eg:         eg,
 		md5OfParts: md5.New(),
 		md5:        md5.New(),
 	}
@@ -98,70 +146,102 @@ func newPutter(url url.URL, h http.Header, c *Config, b *Bucket) (*putter, error
 	}
 
 	p.sp = pool.NewBufferPool(bufferPoolLogger{}, bufsz)
+	pr, pw := io.Pipe()
+	p.pw = pw
+
+	p.eg.Go(func() error {
+		err = p.queueParts(pr)
+		p.closeOnce.Do(func() { pr.Close() })
+		close(p.ch)
+		return err
+	})
+
+	// Close `p.pw` to unblock `queueParts()` (which might be waiting
+	// on `pr.Read()`) if the context is cancelled before `p.Close()`
+	// is called. This also prevents any more successful calls to
+	// `Write()`.
+	go func() {
+		<-ctx.Done()
+		p.closeOnce.Do(func() {
+			p.pw.CloseWithError(errors.New("upload aborted"))
+		})
+	}()
 
 	for i := 0; i < p.c.Concurrency; i++ {
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
-			p.worker()
-		}()
+		p.eg.Go(p.worker)
 	}
 
 	return &p, nil
 }
 
 func (p *putter) Write(b []byte) (int, error) {
-	if p.closed {
-		p.abort()
-		return 0, syscall.EINVAL
+	n, err := p.pw.Write(b)
+	if err == io.ErrClosedPipe {
+		// For backwards compatibility:
+		err = syscall.EINVAL
 	}
-	if p.err != nil {
-		p.abort()
-		return 0, p.err
-	}
-	nw := 0
-	for nw < len(b) {
-		if p.buf == nil {
-			p.buf = p.sp.Get()
-			if int64(cap(p.buf)) < p.bufsz {
-				p.buf = make([]byte, p.bufsz)
-				runtime.GC()
-			}
-		}
-		n := copy(p.buf[p.bufbytes:], b[nw:])
-		p.bufbytes += n
-		nw += n
-
-		if len(p.buf) == p.bufbytes {
-			_ = p.flush()
-		}
-	}
-	return nw, nil
+	return n, err
 }
 
-func (p *putter) flush() error {
-	part, err := p.addPart(p.buf[:p.bufbytes])
-	if err != nil {
-		p.err = err
-	}
-	p.buf, p.bufbytes = nil, 0
+// queueParts reads from `r`, breaks the input into parts of size (at
+// most) `p.bufsz`, adds the data to the hash, and passes each part to
+// `p.ch` to be uploaded by the workers. It terminates when it has
+// exausted the input or experiences a read error.
+func (p *putter) queueParts(r io.Reader) error {
+	for {
+		buf := p.sp.Get()
+		if int64(cap(buf)) != p.bufsz {
+			buf = make([]byte, p.bufsz)
+			runtime.GC()
+		}
+		n, err := io.ReadFull(r, buf)
+		lastPart := false
+		switch err {
+		case nil:
+			// No error. Send this part then continue looping.
+		case io.EOF:
+			if len(p.parts) > 0 {
+				// There was an EOF immediately after the previous
+				// part. This new part would be empty, so we don't
+				// have to send it.
+				return nil
+			}
+			// The file was zero length. In this case, we have to
+			// upload the zero-length part, but then we're done:
+			lastPart = true
+		case io.ErrUnexpectedEOF:
+			// The input was exhausted but only partly filled this
+			// part. Send what we have, then we're done.
+			lastPart = true
+		default:
+			// There was some other kind of error:
+			return err
+		}
 
-	select {
-	case p.ch <- part:
-	case <-p.ctx.Done():
-		return p.ctx.Err()
-	}
+		part, err := p.addPart(buf[:n])
+		if err != nil {
+			return err
+		}
 
-	// if necessary, double buffer size every 2000 parts due to the 10000-part AWS limit
-	// to reach the 5 Terabyte max object size, initial part size must be ~85 MB
-	n := len(p.parts)
-	if n%2000 == 0 && n < maxNPart && growPartSize(n, p.bufsz, p.putsz) {
-		p.bufsz = min64(p.bufsz*2, maxPartSize)
-		p.sp.SetBufferSize(p.bufsz) // update pool buffer size
-		logger.debugPrintf("part size doubled to %d", p.bufsz)
-	}
+		select {
+		case p.ch <- part:
+		case <-p.ctx.Done():
+			return p.ctx.Err()
+		}
 
-	return nil
+		if lastPart {
+			return nil
+		}
+
+		// if necessary, double buffer size every 2000 parts due to the 10000-part AWS limit
+		// to reach the 5 Terabyte max object size, initial part size must be ~85 MB
+		count := len(p.parts)
+		if count%2000 == 0 && count < maxNPart && growPartSize(count, p.bufsz, p.putsz) {
+			p.bufsz = min64(p.bufsz*2, maxPartSize)
+			p.sp.SetBufferSize(p.bufsz) // update pool buffer size
+			logger.debugPrintf("part size doubled to %d", p.bufsz)
+		}
+	}
 }
 
 // newPart creates a new "multipart upload" part containing the bytes
@@ -183,11 +263,14 @@ func (p *putter) addPart(buf []byte) (*s3client.Part, error) {
 	return part, err
 }
 
-func (p *putter) worker() {
+// worker receives parts from `p.ch` that are ready to upload, and
+// uploads them to S3 as file parts. Then it recycles the part's
+// buffer back to the buffer pool.
+func (p *putter) worker() error {
 	for part := range p.ch {
 		err := p.client.UploadPart(p.uploadID, part)
 		if err != nil {
-			p.err = err
+			return err
 		}
 
 		// Give the buffer back to the pool, first making sure
@@ -195,42 +278,51 @@ func (p *putter) worker() {
 		p.sp.Put(part.Data[:cap(part.Data)])
 		part.Data = nil
 	}
+	return nil
 }
 
 func (p *putter) Close() error {
 	defer p.cancel()
+	defer p.sp.Close()
 
-	if p.closed {
-		p.abort()
-		return syscall.EINVAL
+	cleanup := func() {
+		p.cancel()
+		p.eg.Wait()
+		if p.uploadID != "" {
+			err := p.client.AbortMultipartUpload(p.uploadID)
+			if err != nil {
+				logger.Printf("Error aborting multipart upload: %v\n", err)
+			}
+		}
 	}
-	if p.err != nil {
-		p.abort()
-		return p.err
-	}
-	if p.bufbytes > 0 || // partial part
-		len(p.parts) == 0 { // 0 length file
-		_ = p.flush()
-	}
-	close(p.ch)
-	p.wg.Wait()
-	p.closed = true
-	p.sp.Close()
 
-	// check p.err before completing
-	if p.err != nil {
-		p.abort()
-		return p.err
+	// Closing `p.pw` prevents any future `Write()` calls from
+	// succeeding and tells `queueParts()` that no more data is
+	// coming:
+	var err error
+	p.closeOnce.Do(func() {
+		err = p.pw.Close()
+	})
+	if err != nil {
+		cleanup()
+		return errors.New("unexpected error closing internal pipe")
+	}
+
+	err = p.eg.Wait()
+	if err != nil {
+		cleanup()
+		return err
 	}
 
 	eTag, err := p.client.CompleteMultipartUpload(p.uploadID, p.parts)
 	if err != nil {
-		p.abort()
+		cleanup()
 		return err
 	}
 	p.eTag = eTag
 
 	if err := p.checkMd5sOfParts(); err != nil {
+		cleanup()
 		return err
 	}
 
@@ -270,14 +362,6 @@ func (p *putter) checkMd5sOfParts() error {
 	}
 
 	return nil
-}
-
-// Try to abort multipart upload. Do not error on failure.
-func (p *putter) abort() {
-	err := p.client.AbortMultipartUpload(p.uploadID)
-	if err != nil {
-		logger.Printf("Error aborting multipart upload: %v\n", err)
-	}
 }
 
 // Md5 functions

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -126,7 +126,7 @@ func (b *Bucket) GetReader(path string, c *Config) (r io.ReadCloser, h http.Head
 	if err != nil {
 		return nil, nil, err
 	}
-	return newGetter(*u, c, b)
+	return newGetter(u, c, b)
 }
 
 // PutWriter provides a writer to upload data as multipart upload requests.
@@ -144,7 +144,7 @@ func (b *Bucket) PutWriter(path string, h http.Header, c *Config) (w io.WriteClo
 		return nil, err
 	}
 
-	return newPutter(*u, h, c, b)
+	return newPutter(u, h, c, b)
 }
 
 // url returns a parsed url to the given path. c must not be nil

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -81,6 +81,16 @@ var DefaultConfig = &Config{
 	Client:      ClientWithTimeout(clientTimeout),
 }
 
+// safeCopy returns a pointer to a fresh copy of `c`, with some
+// parameters adjusted to be within allowable limits.
+func (c *Config) safeCopy(minPartSize int64) *Config {
+	cCopy := *c
+	cCopy.Concurrency = max(c.Concurrency, 1)
+	cCopy.NTry = max(c.NTry, 1)
+	cCopy.PartSize = max64(minPartSize, cCopy.PartSize)
+	return &cCopy
+}
+
 // http client timeout
 const clientTimeout = 5 * time.Second
 

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -2,6 +2,7 @@ package s3gof3r
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"errors"
 	"flag"
@@ -533,25 +534,227 @@ func TestGetCloseBeforeRead(t *testing.T) {
 	}
 }
 
-func TestPutterAfterError(t *testing.T) {
-	t.Skip("FIXME: test skipped because 'p.err' is no longer exists")
-	w, err := b.PutWriter("test", nil, nil)
+// fakePutter implements `s3Putter` but its `UploadPart()` method
+// always fails.
+type fakePutter struct {
+	ctx        context.Context
+	uploadCh   chan error
+	completeCh chan error
+}
+
+func (p *fakePutter) StartMultipartUpload(_ http.Header) (string, error) {
+	return "fakeUploadID", nil
+}
+
+func (p *fakePutter) UploadPart(_ string, _ *s3client.Part) error {
+	select {
+	case err, ok := <-p.uploadCh:
+		if !ok {
+			return errors.New("upload called too many times")
+		}
+		return err
+	case <-p.ctx.Done():
+		return errors.New("upload context expired")
+	}
+}
+
+func (p *fakePutter) CompleteMultipartUpload(_ string, _ []*s3client.Part) (string, error) {
+	select {
+	case err, ok := <-p.completeCh:
+		if !ok {
+			return "", errors.New("complete called too many times")
+		}
+		return "fakeETag", err
+	case <-p.ctx.Done():
+		return "", errors.New("complete context expired")
+	}
+}
+
+func (p *fakePutter) AbortMultipartUpload(_ string) error {
+	return errors.New("AbortMultipartUpload not implemented")
+}
+
+func (p *fakePutter) PutMD5(_ string) error {
+	return errors.New("PutMD5 not implemented")
+}
+
+func TestPutterUploadError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uploadErr := errors.New("upload error")
+	client := fakePutter{
+		ctx:        ctx,
+		uploadCh:   make(chan error, 1),
+		completeCh: make(chan error, 1),
+	}
+	p, err := newPutter(&client, nil, b.conf())
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("error instantiating putter: %v", err)
 	}
-	p, ok := w.(*putter)
-	if !ok {
-		t.Fatal("putter type cast failed")
+
+	client.uploadCh <- uploadErr
+	close(client.uploadCh)
+
+	_, err = p.Write([]byte("foo"))
+	// We don't insist that this return an error, but if it does it
+	// has to be `uploadErr`.
+	if err != nil && err != uploadErr {
+		t.Errorf("unexpected error on Write: %v", err)
 	}
-	terr := fmt.Errorf("test error")
-	_ = p //p.err = terr
-	_, err = w.Write([]byte("foo"))
-	if err != terr {
-		t.Errorf("expected error %v on Write, got %v", terr, err)
+
+	client.completeCh <- nil
+	err = p.Close()
+	if err != uploadErr {
+		t.Errorf("expected error %v on Close, got %v", uploadErr, err)
 	}
-	err = w.Close()
-	if err != terr {
-		t.Errorf("expected error %v on Close, got %v", terr, err)
+}
+
+func TestBulkPutterUploadError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uploadErr := errors.New("upload error")
+	client := fakePutter{
+		ctx:      ctx,
+		uploadCh: make(chan error, 1),
+	}
+	p, err := newPutter(&client, nil, b.conf())
+	if err != nil {
+		t.Errorf("error instantiating putter: %v", err)
+	}
+
+	client.uploadCh <- uploadErr
+
+	data := []byte("longish string to fill the buffer sooner")
+	for {
+		// After the asynchronous attempt to write the first part is
+		// seen to have failed, but before the second attempt is
+		// allowed to complete, this must return an error:
+		_, err = p.Write(data)
+		if err != nil {
+			if err != uploadErr {
+				t.Errorf("unexpected error on Write: %v", err)
+			}
+			break
+		}
+	}
+
+	// After the first error has occurred, we should continue to get
+	// the same error:
+	_, err = p.Write(data)
+	switch err {
+	case uploadErr:
+		// OK.
+	case nil:
+		t.Errorf("missing error on Write")
+	default:
+		t.Errorf("unexpected error on Write: %v", err)
+	}
+
+	// We should get the same error again from `Close()`, and
+	// `CompleteMultipartUpload()` should never be called (which it
+	// can't be, because `client.completeCh` can't be received from):
+	err = p.Close()
+	if err != uploadErr {
+		t.Errorf("expected error %v on Close, got %v", uploadErr, err)
+	}
+}
+
+func TestBulkPutterSecondUploadError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	uploadErr := errors.New("upload error")
+	client := fakePutter{
+		ctx:      ctx,
+		uploadCh: make(chan error, 1),
+	}
+	p, err := newPutter(&client, nil, b.conf())
+	if err != nil {
+		t.Errorf("error instantiating putter: %v", err)
+	}
+
+	go func() {
+		// Let the first upload succeed:
+		client.uploadCh <- nil
+		// and all subsequent ones fail:
+		for {
+			select {
+			case client.uploadCh <- uploadErr:
+			case <-ctx.Done():
+				break
+			}
+		}
+	}()
+
+	data := []byte("longish string to fill the buffer sooner")
+	for {
+		_, err = p.Write(data)
+		if err != nil {
+			if err != uploadErr {
+				t.Errorf("unexpected error on Write: %v", err)
+			}
+			break
+		}
+	}
+
+	// After the first error has occurred, we should continue to get
+	// the same error:
+	_, err = p.Write(data)
+	switch err {
+	case uploadErr:
+		// OK.
+	case nil:
+		t.Errorf("missing error on Write")
+	default:
+		t.Errorf("unexpected error on Write: %v", err)
+	}
+
+	// We should get the same error again from `Close()`, and
+	// `CompleteMultipartUpload()` should never be called (which it
+	// can't be, because `client.completeCh` can't be received from):
+	err = p.Close()
+	if err != uploadErr {
+		t.Errorf("expected error %v on Close, got %v", uploadErr, err)
+	}
+}
+
+func TestPutterCompleteError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	completeErr := errors.New("complete error")
+	client := fakePutter{
+		ctx:        ctx,
+		uploadCh:   make(chan error),
+		completeCh: make(chan error, 1),
+	}
+	p, err := newPutter(&client, nil, b.conf())
+	if err != nil {
+		t.Errorf("error instantiating putter: %v", err)
+	}
+
+	go func() {
+		// Let all uploads succeed:
+		for {
+			select {
+			case client.uploadCh <- nil:
+			case <-ctx.Done():
+				break
+			}
+		}
+	}()
+
+	_, err = p.Write([]byte("foo"))
+	if err != nil {
+		t.Errorf("unexpected error on Write: %v", err)
+	}
+
+	client.completeCh <- completeErr
+	err = p.Close()
+	if err != completeErr {
+		t.Errorf("expected error %v on Close, got %v", completeErr, err)
 	}
 }
 

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -534,6 +534,7 @@ func TestGetCloseBeforeRead(t *testing.T) {
 }
 
 func TestPutterAfterError(t *testing.T) {
+	t.Skip("FIXME: test skipped because 'p.err' is no longer exists")
 	w, err := b.PutWriter("test", nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -543,7 +544,7 @@ func TestPutterAfterError(t *testing.T) {
 		t.Fatal("putter type cast failed")
 	}
 	terr := fmt.Errorf("test error")
-	p.err = terr
+	_ = p //p.err = terr
 	_, err = w.Write([]byte("foo"))
 	if err != terr {
 		t.Errorf("expected error %v on Write, got %v", terr, err)


### PR DESCRIPTION
This is the next (last?) installment of refactorings to the `putter` code. It changes the code to use some more modern approaches, like contexts, `errgroup.Group`, and an `io.Pipe` to coordinate the goroutines and terminate them gracefully, hopefully without any more data races. It's based on the `s3-client-for-putter` branch (#17) so I'll leave it in draft mode until that PR is reviewed and merged, then probably rebase it.

It can be read commit-by-commit, but that third-to-last commit is a doozy so it might be just as simple to review the whole thing at once (relative to `s3-client-for-putter`). Happily, that other PR removed a lot of verbiage from this file, so I think it's fairly grokable. There's a big comment explaining how things work.

/cc @ccstolley, @carlosmn
