### PR TITLE
Add a function to get status codes from RespError.

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,5 +1,7 @@
 package s3gof3r
 
+import "github.com/github/s3gof3r/internal/s3client"
+
 // convenience multipliers
 const (
 	_        = iota
@@ -44,4 +46,12 @@ type bufferPoolLogger struct{}
 
 func (l bufferPoolLogger) Printf(format string, a ...interface{}) {
 	logger.debugPrintf(format, a...)
+}
+
+func StatusFromError(err error) (int, error) {
+	if e, ok := err.(*s3client.RespError); ok {
+		return e.StatusCode, nil
+	} else {
+		return 0, e
+	}
 }


### PR DESCRIPTION
Some external callers want to be able to extract the HTTP status code
from `RespError`s, so provide a function to do that.

Previously `RespError` was in the `s3gopher` package so it was exported,
but now that `RespError` exists as part of the internal `s3client` package,
it can't be imported outside this project.