### PR TITLE
Update s3gof3r.go

### DIFF
--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -20,7 +20,7 @@ import (
 
 const versionParam = "versionId"
 
-var regionMatcher = regexp.MustCompile("s3[-.]([a-z0-9-]+).amazonaws.com([.a-z0-9]*)")
+var regionMatcher = regexp.MustCompile("s3[-.]([a-z0-9-]+)\.amazonaws\.com([.a-z0-9]*)")
 
 // S3 contains the domain or endpoint of an S3-compatible service and
 // the authentication keys for that service.

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -20,7 +20,7 @@ import (
 
 const versionParam = "versionId"
 
-var regionMatcher = regexp.MustCompile("s3[-.]([a-z0-9-]+)\.amazonaws\.com([.a-z0-9]*)")
+var regionMatcher = regexp.MustCompile(`s3[-.]([a-z0-9-]+)\.amazonaws\.com([.a-z0-9]*)`)
 
 // S3 contains the domain or endpoint of an S3-compatible service and
 // the authentication keys for that service.

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -779,7 +779,7 @@ func TestGetterAfterError(t *testing.T) {
 	}
 }
 
-var regionsTests = []struct {
+var goodRegionsTests = []struct {
 	domain string
 	region string
 	err    error
@@ -789,13 +789,38 @@ var regionsTests = []struct {
 	{domain: "s3-sa-east-1.amazonaws.com", region: "sa-east-1"},
 }
 
-func TestRegion(t *testing.T) {
-	for _, tt := range regionsTests {
+func TestGoodRegion(t *testing.T) {
+	for _, tt := range goodRegionsTests {
 		s3 := &S3{Domain: tt.domain}
 		region := s3.Region()
 		if region != tt.region {
 			t.Errorf("wrong region detected, got '%s', expected '%s'", region, tt.region)
 		}
+	}
+}
+
+var badRegionsTests = []struct {
+	domain string
+	region string
+	err    error
+}{
+	{domain: "bad-amazonaws.com", region: "sa-east-1"},
+	{domain: "s3-sss.amazonaws#com", region: "sa-east-1"},
+}
+
+// Given some bad domains as input
+// When the Region method is called on the domain
+// Then the method should panic because the domain is not recognized
+func TestBadRegion(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+
+	for _, tt := range badRegionsTests {
+		s3 := &S3{Domain: tt.domain}
+		s3.Region()
 	}
 }
 


### PR DESCRIPTION
## Overview

This PR addresses a security vulnerability in which our regex had unescaped dots.

## Implementation

To address the fix, we escape both the dot preceding and following the `amazonaws` string in the regex. This ensures that the regex will only match against supported regions.  This also adds an additional test case to ensure the library panics when an unsupported region is provided. This was previously not the case.

## Testing

Testing for this repo requires that we setup an AWS S3 bucket which I've done. I was then able to get the tests to pass

<img width="648" alt="image" src="https://github.com/user-attachments/assets/f7debf52-3035-492f-b86a-671b23770f00">
